### PR TITLE
Customise external postgresql server port

### DIFF
--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -101,9 +101,12 @@ The following table lists the configurable parameters of the Sentry chart and th
 | `ingress.annotations`                | Ingress annotations                         | `{}`                                                       |
 | `ingress.hostname`                   | URL to address your Sentry installation     | `sentry.local`                                             |
 | `ingress.tls`                        | Ingress TLS configuration                   | `[]`                                                       |
-| `postgresql.enabled`                 | Enable Postgres deployment                  | `true`                                                     |
+| `postgresql.enabled`                 | Deploy postgres server (see below)          | `true`                                                     |
+| `postgresql.postgresDatabase`        | Postgres database name                      | `sentry`                                                   |
+| `postgresql.postgresUser`            | Postgres username                           | `sentry`                                                   |
 | `postgresql.postgresHost`            | External postgres host                      | `nil`                                                      |
 | `postgresql.postgresPassword`        | External postgres password                  | `nil`                                                      |
+| `postgresql.postgresPort`            | External postgres port                      | `5432`                                                     |
 | `persistence.enabled`                | Enable persistence using PVC                | `true`                                                     |
 | `persistence.storageClass`           | PVC Storage Class                           | `nil` (uses alpha storage class annotation)                |
 | `persistence.accessMode`             | PVC Access Mode                             | `ReadWriteOnce`                                            |
@@ -131,7 +134,7 @@ $ helm install --name my-release -f values.yaml stable/sentry
 
 ## PostgresSQL
 
-By default, PostgreSQL in installed as part of the chart. To use an external PostgreSQL server set `postgresql.enabled` to `false` and set `postgresql.postgresHost` and `postgresql.postgresPassword` accordingly.
+By default, PostgreSQL is installed as part of the chart. To use an external PostgreSQL server set `postgresql.enabled` to `false` and then set `postgresql.postgresHost` and `postgresql.postgresPassword`. The other options (`postgresql.postgresDatabase`, `postgresql.postgresUser` and `postgresql.postgresPort`) may also want changing from their default values.
 
 ## Persistence
 

--- a/stable/sentry/templates/_helpers.tpl
+++ b/stable/sentry/templates/_helpers.tpl
@@ -50,3 +50,14 @@ Set postgres secret
 {{- template "fullname" . -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Set postgres port
+*/}}
+{{- define "postgresql.port" -}}
+{{- if .Values.postgresql.enabled -}}
+    "5432"
+{{- else -}}
+{{- default "5432" .Values.postgresql.postgresPort | quote -}}
+{{- end -}}
+{{- end -}}

--- a/stable/sentry/templates/cron-deployment.yaml
+++ b/stable/sentry/templates/cron-deployment.yaml
@@ -68,7 +68,7 @@ spec:
         - name: SENTRY_POSTGRES_HOST
           value: {{ template "postgresql.host" . }}
         - name: SENTRY_POSTGRES_PORT
-          value: "5432"
+          value: {{ template "postgresql.port" . }}
         - name: SENTRY_REDIS_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/stable/sentry/templates/hooks/db-init.job.yaml
+++ b/stable/sentry/templates/hooks/db-init.job.yaml
@@ -52,7 +52,7 @@ spec:
         - name: SENTRY_POSTGRES_HOST
           value: {{ template "postgresql.host" . }}
         - name: SENTRY_POSTGRES_PORT
-          value: "5432"
+          value: {{ template "postgresql.port" . }}
         - name: SENTRY_REDIS_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/stable/sentry/templates/hooks/user-create.job.yaml
+++ b/stable/sentry/templates/hooks/user-create.job.yaml
@@ -52,7 +52,7 @@ spec:
         - name: SENTRY_POSTGRES_HOST
           value: {{ template "postgresql.host" . }}
         - name: SENTRY_POSTGRES_PORT
-          value: "5432"
+          value: {{ template "postgresql.port" . }}
         - name: SENTRY_REDIS_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/stable/sentry/templates/web-deployment.yaml
+++ b/stable/sentry/templates/web-deployment.yaml
@@ -67,7 +67,7 @@ spec:
         - name: SENTRY_POSTGRES_HOST
           value: {{ template "postgresql.host" . }}
         - name: SENTRY_POSTGRES_PORT
-          value: "5432"
+          value: {{ template "postgresql.port" . }}
         - name: SENTRY_REDIS_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/stable/sentry/templates/workers-deployment.yaml
+++ b/stable/sentry/templates/workers-deployment.yaml
@@ -68,7 +68,7 @@ spec:
         - name: SENTRY_POSTGRES_HOST
           value: {{ template "postgresql.host" . }}
         - name: SENTRY_POSTGRES_PORT
-          value: "5432"
+          value: {{ template "postgresql.port" . }}
         - name: SENTRY_REDIS_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -146,6 +146,7 @@ postgresql:
   # Only used when internal PG is disabled
   # postgresHost: postgres
   # postgresPassword: postgres
+  # postgresPort: 5432
   imageTag: "9.6"
   persistence:
     enabled: true


### PR DESCRIPTION
**What this PR does / why we need it**:
* Add value to customise external postgresql server port

It was tempting to refactor more (e.g. renaming `postgresql.postgresParam` to just `postgresql.param` and/or make `postgresHost` and `postgresPassword` set to `sentry` by default for non-external postgres deployments), but I decided against it in favour of backwards compatibility.

**Which issue this PR fixes**: Contribution towards #7449
